### PR TITLE
Use userip param for google image search api.

### DIFF
--- a/lib/lita/handlers/google_images.rb
+++ b/lib/lita/handlers/google_images.rb
@@ -1,4 +1,5 @@
 require "lita"
+require "socket"
 
 module Lita
   module Handlers
@@ -21,7 +22,8 @@ module Lita
           v: "1.0",
           q: query,
           safe: safe_value,
-          rsz: 8
+          rsz: 8, 
+          userip: (IPSocket.getaddress(Socket.gethostname) rescue nil)
         )
 
         data = MultiJson.load(http_response.body)


### PR DESCRIPTION
Was getting a qps exceeded error from the google image search API when used from heroku. Adding the userip param seems to have fixe it.
