### PR TITLE
:sparkles: Add `animate me` behavior

### DIFF
--- a/lib/lita/handlers/google_images.rb
+++ b/lib/lita/handlers/google_images.rb
@@ -26,7 +26,7 @@ module Lita
       })
 
       def fetch_anim(response)
-        fetch(response, animated = true)
+        fetch(response, true)
       end
 
       def fetch(response, animated = false)
@@ -43,7 +43,14 @@ module Lita
           key: config.google_cse_key
         }
 
-        query_params["fileType"] = "gif" if animated
+        if animated
+          animated_params = {
+            fileType: "gif",
+            hq: "animated",
+            tbs: "itp:animated"
+          }
+          query_params.merge!(animated_params)
+        end
 
         http_response = http.get(
           URL,

--- a/lib/lita/handlers/google_images.rb
+++ b/lib/lita/handlers/google_images.rb
@@ -21,11 +21,18 @@ module Lita
         "image QUERY" => "Displays a random image from Google Images matching the query."
       })
 
-      def fetch(response)
+      route(/(?:animate|gif)(?:\s+me)? (.+)/i, :fetch_anim, command: true, help: {
+        "animate QUERY" => "Displays a random animation from Google Images matching the query."
+      })
+
+      def fetch_anim(response)
+        fetch(response, animated = true)
+      end
+
+      def fetch(response, animated = false)
         query = response.matches[0][0]
 
-        http_response = http.get(
-          URL,
+        query_params = {
           v: "1.0",
           searchType: 'image',
           q: query,
@@ -34,6 +41,13 @@ module Lita
           rsz: 8,
           cx: config.google_cse_id,
           key: config.google_cse_key
+        }
+
+        query_params["fileType"] = "gif" if animated
+
+        http_response = http.get(
+          URL,
+          query_params
         )
 
         data = MultiJson.load(http_response.body)

--- a/spec/lita/handlers/google_images_spec.rb
+++ b/spec/lita/handlers/google_images_spec.rb
@@ -7,6 +7,12 @@ describe Lita::Handlers::GoogleImages, lita_handler: true do
   it { is_expected.to route_command("img me foo").to(:fetch) }
   it { is_expected.to route_command("IMAGE FOO").to(:fetch) }
 
+  it { is_expected.to route_command("animate me foo").to(:fetch_anim) }
+  it { is_expected.to route_command("animate foo").to(:fetch_anim) }
+  it { is_expected.to route_command("gif foo").to(:fetch_anim) }
+  it { is_expected.to route_command("gif me foo").to(:fetch_anim) }
+  it { is_expected.to route_command("ANIMATE FOO").to(:fetch_anim) }
+
   describe "#foo" do
     let(:response) { double("Faraday::Response", status: 200,) }
     let(:fail_response) { double("Faraday::Response", status: 500) }
@@ -59,6 +65,23 @@ JSON
         )
         send_command("image carl")
         expect(replies.last).to eq(%{No images found for "carl".})
+      end
+
+      it 'replies with an animation when requested' do
+        allow(response).to receive(:body).and_return(<<-JSON.chomp
+{
+  "items": [
+    {
+      "link": "http://www.example.com/path/to/an/animation.gif"
+    }
+  ]
+}
+JSON
+        )
+        send_command("animate carl")
+        expect(replies.last).to eq(
+          "http://www.example.com/path/to/an/animation.gif"
+        )
       end
     end
 


### PR DESCRIPTION
The Google Custom Search API allows for a parameter to be passed to
specify the returned fileType.
The `imgType` does not currently support animated as a parameter, so we
can submit with `fileType:gif` to get animated images.
- Pop the query params out to its own Hash, so we can conditionally add to
  it before performing the `.get()`
- Add an input paramter to `fetch()` to control behavior
- Add a new route & method to control input to `.fetch()`

Closes #7 

---

@jimmycuadra This was how I was able to implement the desired behavior - and testing with real keys, I can confirm that it works as intended.

I'm not 100% sure this is the best approach, but I couldn't figure out a way to introspect the `command` to determine if the behavior should be image or animate.
The `fetch_anim()` method also felt a bit odd, for the same reason - totally open to other ideas/approaches for this.
