### PR TITLE
Add instructions for populating required attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem "lita-google-images"
 ### Required attributes
 
 ```
-* `google_cse_id` (String) - ID of the Google Custom Search account to use.
+* `google_cse_id` (String) - ID of the Google Custom Search Engine to use.
 * `google_cse_key` (String) - API key for the Google Custom Search account.
 ```
 
@@ -56,6 +56,31 @@ Lita: gif me carl the pug
 ```
 
 The second form ("verb me") is to ease the transition for people coming from [Hubot](http://hubot.github.com/).
+
+## Getting a CSE ID and API key
+For the `google_cse_id` and `google_cse_key` you will need to get a Custom Search Engine ID and a Google API key.
+
+### Getting a Custom Search Engine ID
+The custom search engine is used to fetch images. Here is how to create one:
+
+1. [Head to the CSE creation page](https://cse.google.com/cse/create/new)
+2. Enter any url in the "sites to search" field. We will open the CSE to the whole web later on.
+3. Give your CSE a name and hit create
+4. Go to the control panel for your new CSE
+5. Change the "Image search" switch to ON
+6. Change the "Search the entire web" switch to ON
+7. `google_cse_id` is the value of "Search engine ID"
+
+### Getting a Google API key
+The final attribute you need to set is the Google API key.
+
+1. [Head to the Google Developers Console](https://console.developers.google.com)
+2. Create a new project for your lita bot
+3. Add the Custom Search API to your project
+4. Click on Credentials in the menu on the left
+5. Click on Create Credentials
+6. Select "API key"
+7. `google_cse_key` is the value of your new API key
 
 ## License
 


### PR DESCRIPTION
I added a section in the README explaining how to create the Custom Search Engine and how to get an API key to populate the required attributes. This should close #9 